### PR TITLE
fix(aomic-piop1): correct dataset card metadata and test fixtures

### DIFF
--- a/docs/dataset-cards/aomic-piop1.md
+++ b/docs/dataset-cards/aomic-piop1.md
@@ -17,9 +17,11 @@ size_categories:
   - n<1K
 ---
 
-# AOMIC-PIOP1 Dataset
+# AOMIC-PIOP1 Dataset (V1 - Raw BIDS)
 
 Amsterdam Open MRI Collection - Population Imaging of Psychology Dataset 1 (PIOP1).
+
+> **Version Note:** This is V1 containing raw BIDS data only (~118 GB). Preprocessed derivatives (fMRIprep, FreeSurfer, etc.) are not included. See [What's Not Included](#whats-not-included-v2-planned) below.
 
 ## Dataset Description
 
@@ -55,6 +57,27 @@ print(example["age"])          # Age in years
 print(example["sex"])          # Sex (M/F)
 print(example["handedness"])   # Handedness (left/right/ambidextrous)
 ```
+
+## What's Not Included (V2 Planned)
+
+**V1 (current)** contains raw BIDS data only (~118 GB):
+- T1-weighted structural (raw)
+- Diffusion-weighted imaging (raw)
+- BOLD fMRI (raw, all tasks)
+- Demographics (age, sex, handedness)
+
+**V2 (planned)** will add preprocessed derivatives (~540 GB additional):
+
+| Derivative | Description | Size |
+|------------|-------------|------|
+| fMRIprep | Preprocessed fMRI (motion corrected, normalized) | ~large |
+| FreeSurfer | Cortical surface reconstructions, parcellations | ~large |
+| dwipreproc | Preprocessed diffusion data | ~medium |
+| MRIQC | Image quality control metrics | ~small |
+| VBM | Voxel-based morphometry outputs | ~medium |
+| Physiology | Physiological recordings (breathing, heart rate) | ~small |
+
+The full OpenNeuro source (ds002785) is ~657 GB total. Most ML/DL research uses preprocessed derivatives, which require ~6-12 hours of compute per subject to generate from raw data.
 
 ## Citation
 

--- a/docs/dataset-cards/aomic-piop1.md
+++ b/docs/dataset-cards/aomic-piop1.md
@@ -17,11 +17,11 @@ size_categories:
   - n<1K
 ---
 
-# AOMIC-PIOP1 Dataset (V1 - Raw BIDS)
+# AOMIC-PIOP1 Dataset
 
 Amsterdam Open MRI Collection - Population Imaging of Psychology Dataset 1 (PIOP1).
 
-> **Version Note:** This is V1 containing raw BIDS data only (~118 GB). Preprocessed derivatives (fMRIprep, FreeSurfer, etc.) are not included. See [What's Not Included](#whats-not-included-v2-planned) below.
+> **Scope:** This HuggingFace dataset is derived from OpenNeuro ds002785 and includes the raw imaging NIfTI files (T1w, DWI, BOLD) plus selected participant metadata (age, sex, handedness). It does not include the original BIDS layout, sidecar files, or derivatives.
 
 ## Dataset Description
 
@@ -58,26 +58,12 @@ print(example["sex"])          # Sex (M/F)
 print(example["handedness"])   # Handedness (left/right/ambidextrous)
 ```
 
-## What's Not Included (V2 Planned)
+## What's Not Included
 
-**V1 (current)** contains raw BIDS data only (~118 GB):
-- T1-weighted structural (raw)
-- Diffusion-weighted imaging (raw)
-- BOLD fMRI (raw, all tasks)
-- Demographics (age, sex, handedness)
+- Full BIDS sidecars and auxiliary files (e.g., `events.tsv`, `*_physio.tsv.gz`, JSON sidecars, `bvec`/`bval`, full `participants.tsv`/`participants.json`).
+- OpenNeuro derivatives in `derivatives/` (e.g., `fmriprep`, `freesurfer`, `fs_stats`, `dwipreproc`, `mriqc`, `vbm`, `physiology`).
 
-**V2 (planned)** will add preprocessed derivatives (~540 GB additional):
-
-| Derivative | Description | Size |
-|------------|-------------|------|
-| fMRIprep | Preprocessed fMRI (motion corrected, normalized) | ~large |
-| FreeSurfer | Cortical surface reconstructions, parcellations | ~large |
-| dwipreproc | Preprocessed diffusion data | ~medium |
-| MRIQC | Image quality control metrics | ~small |
-| VBM | Voxel-based morphometry outputs | ~medium |
-| Physiology | Physiological recordings (breathing, heart rate) | ~small |
-
-The full OpenNeuro source (ds002785) is ~657 GB total. Most ML/DL research uses preprocessed derivatives, which require ~6-12 hours of compute per subject to generate from raw data.
+For the complete raw BIDS release and all derivatives, download from OpenNeuro ds002785.
 
 ## Citation
 

--- a/docs/dataset-cards/aomic-piop1.md
+++ b/docs/dataset-cards/aomic-piop1.md
@@ -1,7 +1,7 @@
 ---
 license: cc0-1.0
 task_categories:
-  - image-classification
+  - other
 tags:
   - medical
   - neuroimaging
@@ -14,7 +14,7 @@ tags:
   - AOMIC
   - OpenNeuro
 size_categories:
-  - 100K<n<1M
+  - n<1K
 ---
 
 # AOMIC-PIOP1 Dataset
@@ -49,11 +49,11 @@ ds = load_dataset("hugging-science/aomic-piop1", split="train")
 example = ds[0]
 print(example["subject_id"])  # "sub-0001"
 print(example["t1w"])         # NIfTI array (T1-weighted structural)
-print(example["dwi"])          # List of NIfTI arrays (multiple runs)
+print(example["dwi"])          # List of NIfTI arrays (single file per subject)
 print(example["bold"])         # List of NIfTI arrays (multiple tasks)
 print(example["age"])          # Age in years
 print(example["sex"])          # Sex (M/F)
-print(example["handedness"])   # Handedness (L/R)
+print(example["handedness"])   # Handedness (left/right/ambidextrous)
 ```
 
 ## Citation

--- a/tests/test_aomic_piop1.py
+++ b/tests/test_aomic_piop1.py
@@ -43,8 +43,8 @@ def synthetic_aomic_piop1_bids_root() -> Generator[Path, None, None]:
         │   ├── dwi/
         │   │   └── sub-0001_dwi.nii.gz
         │   └── func/
-        │       ├── sub-0001_task-restingstate_bold.nii.gz
-        │       └── sub-0001_task-stopsignal_bold.nii.gz
+        │       ├── sub-0001_task-restingstate_acq-mb3_bold.nii.gz
+        │       └── sub-0001_task-emomatching_acq-seq_bold.nii.gz
         ├── sub-0002/
         │   └── anat/
         │       └── sub-0002_T1w.nii.gz  (minimal - only T1w)
@@ -60,7 +60,7 @@ def synthetic_aomic_piop1_bids_root() -> Generator[Path, None, None]:
                 "participant_id": ["sub-0001", "sub-0002", "sub-0003"],
                 "age": [25.0, 30.0, 28.0],
                 "sex": ["F", "M", "F"],
-                "handedness": ["R", "R", "L"],
+                "handedness": ["right", "right", "left"],
             }
         )
         participants.to_csv(root / "participants.tsv", sep="\t", index=False)
@@ -69,9 +69,10 @@ def synthetic_aomic_piop1_bids_root() -> Generator[Path, None, None]:
         _create_minimal_nifti(root / "sub-0001" / "anat" / "sub-0001_T1w.nii.gz")
         # Single DWI file (AOMIC-PIOP1 pattern)
         _create_minimal_nifti(root / "sub-0001" / "dwi" / "sub-0001_dwi.nii.gz")
-        # Multiple BOLD tasks
-        _create_minimal_nifti(root / "sub-0001" / "func" / "sub-0001_task-restingstate_bold.nii.gz")
-        _create_minimal_nifti(root / "sub-0001" / "func" / "sub-0001_task-stopsignal_bold.nii.gz")
+        # Multiple BOLD tasks (realistic AOMIC-PIOP1 naming with acq-* entities)
+        sub1_func = root / "sub-0001" / "func"
+        _create_minimal_nifti(sub1_func / "sub-0001_task-restingstate_acq-mb3_bold.nii.gz")
+        _create_minimal_nifti(sub1_func / "sub-0001_task-emomatching_acq-seq_bold.nii.gz")
 
         # sub-0002: has T1w only (minimal)
         _create_minimal_nifti(root / "sub-0002" / "anat" / "sub-0002_T1w.nii.gz")
@@ -138,7 +139,7 @@ class TestBuildAomicPiop1FileTable:
         # Metadata
         assert sub1["age"] == 25.0
         assert sub1["sex"] == "F"
-        assert sub1["handedness"] == "R"
+        assert sub1["handedness"] == "right"
 
     def test_build_file_table_subject_partial_modalities(
         self, synthetic_aomic_piop1_bids_root: Path
@@ -153,9 +154,7 @@ class TestBuildAomicPiop1FileTable:
         assert sub2["dwi"] == []  # No dwi/ directory
         assert sub2["bold"] == []  # No func/ directory
 
-    def test_build_file_table_dwi_as_list(
-        self, synthetic_aomic_piop1_bids_root: Path
-    ) -> None:
+    def test_build_file_table_dwi_as_list(self, synthetic_aomic_piop1_bids_root: Path) -> None:
         """Test that DWI files are captured as list (even when single file)."""
         df = build_aomic_piop1_file_table(synthetic_aomic_piop1_bids_root)
         sub1 = df[df["subject_id"] == "sub-0001"].iloc[0]
@@ -206,12 +205,12 @@ class TestBuildAomicPiop1FileTable:
         # sub-0001 metadata
         assert sub1["age"] == 25.0
         assert sub1["sex"] == "F"
-        assert sub1["handedness"] == "R"
+        assert sub1["handedness"] == "right"
 
         # sub-0002 metadata
         assert sub2["age"] == 30.0
         assert sub2["sex"] == "M"
-        assert sub2["handedness"] == "R"
+        assert sub2["handedness"] == "right"
 
     def test_build_file_table_missing_participants_raises(self, tmp_path: Path) -> None:
         """Test that missing participants.tsv raises FileNotFoundError."""


### PR DESCRIPTION
## Summary

Minor fixes to AOMIC-PIOP1 dataset card metadata and test fixtures to align with OpenNeuro ds002785 SSOT.

Follow-up to MarioAderman's AOMIC-PIOP1 implementation (PR #22).

## Changes

### Dataset Card (`docs/dataset-cards/aomic-piop1.md`)
- `task_categories`: `image-classification` → `other` (neuroimaging research data)
- `size_categories`: `100K<n<1M` → `n<1K` (216 subjects)
- DWI usage comment: "multiple runs" → "single file per subject"
- handedness comment: `L/R` → `left/right/ambidextrous` (match real data values)

### Test Fixtures (`tests/test_aomic_piop1.py`)
- handedness values: `R/L` → `right/left` (match OpenNeuro ds002785)
- BOLD task names: `task-stopsignal` → `task-emomatching_acq-seq` (realistic naming)

## Verification

- All 19 AOMIC-PIOP1 tests pass
- Linting (ruff) passes
- Type checking (mypy) passes

## Test Plan

- [x] `uv run pytest tests/test_aomic_piop1.py` passes
- [x] `uv run ruff check .` passes
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded AOMIC‑PIOP1 docs with scope, what's not included, provenance reference to original source, clarified metadata descriptions, and improved topic tags.
* **Bug Fixes**
  * Corrected dataset size and task category labels; standardized handedness values to full descriptive terms.
* **Tests**
  * Updated test dataset and assertions to match new naming and metadata conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->